### PR TITLE
npm パッケージインストールでバージョンをピン留めする

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 shamefully-hoist=true
 strict-peer-dependencies=false
+save-exact=true


### PR DESCRIPTION
## やりたいこと
 - npm パッケージをインストールするときにバージョンをピン留めしたい。
   - 万が一想定していないバージョンがインストールされるのを防ぐため。バージョンの更新は手作業でやるのではなく、renovate や dependabot ようなバージョン更新ツールに任せる予定なので、バージョンが変更されるタイミングを自動作成 PR をマージしたときだけにする 