### PR TITLE
release pr 作成の github actions を追加

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,31 @@
+name: Create a release pull request
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.5
+
+      - name: Creates a release pull request
+        env:
+          GIT_PR_RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_PR_RELEASE_BRANCH_PRODUCTION: release
+          GIT_PR_RELEASE_BRANCH_STAGING: main
+          GIT_PR_RELEASE_TEMPLATE: .github/template/github-release-pr-template
+        run: |
+          gem install -N git-pr-release -v "1.4.0"
+          git-pr-release --no-fetch

--- a/.github/workflows/template/release-pr-template
+++ b/.github/workflows/template/release-pr-template
@@ -1,0 +1,4 @@
+Release/<%= Time.now.strftime('%Y%m%d') %>
+<% pull_requests.each do |pr| -%>
+<%=  pr.to_checklist_item %>
+<% end -%>


### PR DESCRIPTION
## やりたいこと
 - 本番で動いているコードを置くブランチと開発用のブランチを分け、release ブランチにコードがマージされたら、deploy workflow を動かす想定にする。
 - main から release ブランチへの PR 作成を自動化し、シンプルに手作業をなくすのと今まで main に新しく入った PR 一覧をまとめてどんな変更が入るかをわかりやすくまとめたい