### PR TITLE
記事内の外部サイトを別タブで開くようにする

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -69,6 +69,17 @@ export default defineNuxtConfig({
   },
 
   content: {
+    markdown: {
+      rehypePlugins: [
+        [
+          'rehype-external-links', {
+            target: '_blank',
+            rel: 'nofollow noopener noreferrer',
+          },
+        ],
+      ],
+    },
+
     highlight: {
       theme: {
         default: 'material-theme',


### PR DESCRIPTION
## やりたいこと
 - マークダウン内の外部リンクについて、どうやら nuxt/mdc が使用している rehype プラグインのデフォルトの挙動が a タグを別タブで開かないようになっているので、別タブで開くように挙動をカスタマイズする