### PR TITLE
記事の中の見出しをクリックしたときになめらかにスクロールするように

### DIFF
--- a/src/app/router.options.ts
+++ b/src/app/router.options.ts
@@ -1,0 +1,33 @@
+import { useNuxtApp } from '#imports'
+import type { RouterConfig } from '@nuxt/schema'
+
+import { findHashPosition } from '~/utils/router/hashPosition'
+
+export default <RouterConfig>{
+  scrollBehavior(to, from, savedPosition) {
+    const nuxtApp = useNuxtApp()
+
+    if (savedPosition) {
+      return new Promise((resolve) => {
+        nuxtApp.hooks.hookOnce('page:finish', () => {
+          setTimeout(() => resolve(savedPosition), 50)
+        })
+      })
+    }
+
+    if (to.hash) {
+      return new Promise((resolve) => {
+        // 投稿された記事の見出しをクリックしたときにスクロールが発生するようにする
+        if (to.path === from.path) {
+          setTimeout(() => resolve(findHashPosition(to.hash)), 50)
+        } else {
+          nuxtApp.hooks.hookOnce('page:finish', () => {
+            setTimeout(() => resolve(findHashPosition(to.hash)), 50)
+          })
+        }
+      })
+    }
+
+    return { top: 0 }
+  },
+}

--- a/src/utils/router/hashPosition.ts
+++ b/src/utils/router/hashPosition.ts
@@ -1,0 +1,12 @@
+export const findHashPosition = (hash: string): { el: string, behavior: ScrollBehavior, top: number } | undefined => {
+  const el = document.querySelector(hash)
+  if (!el) return undefined
+
+  const top = parseFloat(getComputedStyle(el).scrollMarginTop)
+
+  return {
+    el: hash,
+    behavior: 'smooth',
+    top,
+  }
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -196,6 +196,7 @@ export default {
           },
           primary: {
             css: {
+              '--scroll-mt': '80px',
               '--tw-prose-body': 'rgb(var(--color-gray-700))',
               '--tw-prose-headings': 'rgb(var(--color-gray-900))',
               '--tw-prose-lead': 'rgb(var(--color-gray-600))',


### PR DESCRIPTION
## やりたいこと
 - 記事の中に見出しにクリックしたときになめらかにスクロールするように
 - behaviorType を`smooth` にしたが、どうやらそれだけだと scroll-margin-top が効かないみたいなので。回避策として、`app/router.options.ts` の処理の中で scroll margin top を取得する