### PR TITLE
draft 状態の記事を prerender に含めないように

### DIFF
--- a/utils/config/nitro/getContentRoutes.ts
+++ b/utils/config/nitro/getContentRoutes.ts
@@ -19,6 +19,9 @@ export const getContentRoutes = (): string[] => {
   let allPageCount = 0
   const markdownNumByCategoryMap: Record<string, number> = {}
   for (const markdownFile of markdownFiles) {
+    const frontmatter = getFrontMatter(`${markdownFile.path}/${markdownFile.name}`)
+    if (frontmatter.draft) continue
+
     allPageCount++
 
     const path = `${markdownFile.path}/${markdownFile.name}`
@@ -27,9 +30,6 @@ export const getContentRoutes = (): string[] => {
       .replace('.md', '')
 
     postRoutes.push(`/posts${path}`)
-
-    const frontmatter = getFrontMatter(`${markdownFile.path}/${markdownFile.name}`)
-    if (frontmatter.draft) continue
 
     for (const category of frontmatter.categories) {
       const urlParamCategory = categoryUrlParamsMap[category] || category

--- a/utils/config/nitro/getContentRoutes.ts
+++ b/utils/config/nitro/getContentRoutes.ts
@@ -1,4 +1,5 @@
 import { readdirSync, readFileSync } from 'fs'
+import { join } from 'path'
 
 import { parseFrontMatter } from 'remark-mdc'
 
@@ -29,7 +30,7 @@ export const getContentRoutes = (): string[] => {
       .replaceAll('src/content', '')
       .replace('.md', '')
 
-    postRoutes.push(`/posts${path}`)
+    postRoutes.push(join('/posts', path))
 
     for (const category of frontmatter.categories) {
       const urlParamCategory = categoryUrlParamsMap[category] || category
@@ -49,7 +50,7 @@ export const getContentRoutes = (): string[] => {
   }
 
   postRoutes.push(...Array.from({ length: maxPageNum }, (_, pageNum) => pageNum + 1)
-    .map((pageNum) => `/posts/${pageNum}`))
+    .map((pageNum) => join('/posts', pageNum.toString())))
 
   const contentRoutes: string[] = []
 
@@ -66,7 +67,7 @@ export const getContentRoutes = (): string[] => {
     }
 
     const categoryPageRoutes = Array.from({ length: categoryPageCount }, (_, pageNum) => pageNum + 1)
-      .map((pageNum) => `/posts/categories/${urlParamCategory.toLowerCase()}/${pageNum}`)
+      .map((pageNum) => join('/posts/categories', urlParamCategory.toLowerCase(), pageNum.toString()))
 
     contentRoutes.push(...categoryPageRoutes)
   }


### PR DESCRIPTION
## やりたいこと
 - 記事が draft か否かを確認するのに、確認タイミングが遅かったため、draft の記事が入っていたのを修正。
 - パスの生成もバグの温床になる可能性があるので、今のうちに join を使って防いでおく
 