### PR TITLE
ページにそれぞれ title を振るように

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -1,5 +1,13 @@
 <script setup lang="ts">
+import { useHead } from '#imports'
+
 import AppHeader from '~/components/header/AppHeader.vue'
+
+useHead({
+  titleTemplate: (title) => {
+    return title ? `${title} | offich.me` : 'offich.me'
+  },
+})
 </script>
 
 <template>

--- a/src/pages/about/index.vue
+++ b/src/pages/about/index.vue
@@ -1,3 +1,15 @@
+<script setup lang="ts">
+import { useHead, useSeoMeta } from '#imports'
+
+useHead({
+  title: 'About',
+})
+
+useSeoMeta({
+  robots: 'noindex',
+})
+</script>
+
 <template>
   <div class="p-2 max-w-6xl mx-auto min-h-screen">
     <p>coming soon...</p>

--- a/src/pages/about/index.vue
+++ b/src/pages/about/index.vue
@@ -5,7 +5,11 @@ useHead({
   title: 'About',
 })
 
+const seoMetaDescription = '自身について'
+
 useSeoMeta({
+  description: seoMetaDescription,
+  ogDescription: seoMetaDescription,
   robots: 'noindex',
 })
 </script>

--- a/src/pages/bartender/index.vue
+++ b/src/pages/bartender/index.vue
@@ -6,6 +6,7 @@ useHead({
 })
 
 useSeoMeta({
+  description: 'お酒作りについて',
   robots: 'noindex',
 })
 </script>

--- a/src/pages/bartender/index.vue
+++ b/src/pages/bartender/index.vue
@@ -1,3 +1,15 @@
+<script setup lang="ts">
+import { useHead, useSeoMeta } from '#imports'
+
+useHead({
+  title: 'Bartender',
+})
+
+useSeoMeta({
+  robots: 'noindex',
+})
+</script>
+
 <template>
   <div class="p-2 max-w-6xl mx-auto min-h-screen">
     <p>coming soon...</p>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,9 +1,16 @@
 <script setup lang="ts">
-import { computed } from '#imports'
+import { computed, useSeoMeta } from '#imports'
 import type { QueryBuilderParams } from '@nuxt/content'
 
 import HomeAside from '~/components/home/HomeAside.vue'
 import PostList from '~/components/post/PostList.vue'
+
+const seoMetaDescription = 'Web フロント・モバイルアプリエンジニア。Nuxt.js と Flutter が得意です。歌とお酒が好きです。'
+
+useSeoMeta({
+  description: seoMetaDescription,
+  ogDescription: seoMetaDescription,
+})
 
 const query = computed<QueryBuilderParams>(() => {
   return {

--- a/src/pages/music/index.vue
+++ b/src/pages/music/index.vue
@@ -6,6 +6,7 @@ useHead({
 })
 
 useSeoMeta({
+  description: '音楽活動について',
   robots: 'noindex',
 })
 </script>

--- a/src/pages/music/index.vue
+++ b/src/pages/music/index.vue
@@ -1,3 +1,15 @@
+<script setup lang="ts">
+import { useHead, useSeoMeta } from '#imports'
+
+useHead({
+  title: 'Music',
+})
+
+useSeoMeta({
+  robots: 'noindex',
+})
+</script>
+
 <template>
   <div class="p-2 max-w-6xl mx-auto min-h-screen">
     <p>coming soon...</p>

--- a/src/pages/posts/[page].vue
+++ b/src/pages/posts/[page].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useRoute, computed, queryContent, useAsyncData, definePageMeta } from '#imports'
+import { useRoute, computed, queryContent, useAsyncData, definePageMeta, useHead } from '#imports'
 import type { QueryBuilderParams } from '@nuxt/content'
 
 import PostList from '~/components/post/PostList.vue'
@@ -18,6 +18,14 @@ const page = computed(() => {
   } else {
     return route.params.page ? parseInt(route.params.page, 10) : 1
   }
+})
+
+const headTitle = computed<string>(() => {
+  return `記事一覧 ${page.value}ページ目`
+})
+
+useHead({
+  title: headTitle.value,
 })
 
 const query = computed<QueryBuilderParams>(() => {

--- a/src/pages/posts/[page].vue
+++ b/src/pages/posts/[page].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useRoute, computed, queryContent, useAsyncData, definePageMeta, useHead } from '#imports'
+import { useRoute, computed, queryContent, useAsyncData, definePageMeta, useHead, useSeoMeta } from '#imports'
 import type { QueryBuilderParams } from '@nuxt/content'
 
 import PostList from '~/components/post/PostList.vue'
@@ -26,6 +26,11 @@ const headTitle = computed<string>(() => {
 
 useHead({
   title: headTitle.value,
+})
+
+useSeoMeta({
+  description: `記事一覧の${page.value}ページ目です。技術、音楽、お酒や日ごろのことをのんびり書きます。`,
+  ogDescription: `記事一覧の${page.value}ページ目です。技術、音楽、お酒や日ごろのことをのんびり書きます。`,
 })
 
 const query = computed<QueryBuilderParams>(() => {

--- a/src/pages/posts/categories/[category]/[page].vue
+++ b/src/pages/posts/categories/[category]/[page].vue
@@ -45,6 +45,7 @@ useHead({
 })
 
 useSeoMeta({
+  title: headTitle.value,
   description: `${headTitle.value}です。`,
 })
 

--- a/src/pages/posts/categories/[category]/[page].vue
+++ b/src/pages/posts/categories/[category]/[page].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useRoute, computed, queryContent, useAsyncData, definePageMeta } from '#imports'
+import { useRoute, computed, queryContent, useAsyncData, definePageMeta, useHead } from '#imports'
 import type { QueryBuilderParams } from '@nuxt/content'
 
 import PostList from '~/components/post/PostList.vue'
@@ -32,6 +32,16 @@ const cateogryParams = computed<string>(() => {
   }
 
   return `${category.charAt(0).toUpperCase()}${category.slice(1)}` // capitalize
+})
+
+const headTitle = computed(() => {
+  const category = cateogryParams.value === 'Tech' ? '技術関連の記事' : `${cateogryParams.value} の記事`
+
+  return `${category} ${page.value}ページ目`
+})
+
+useHead({
+  title: headTitle.value,
 })
 
 const query = computed<QueryBuilderParams>(() => {

--- a/src/pages/posts/categories/[category]/[page].vue
+++ b/src/pages/posts/categories/[category]/[page].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useRoute, computed, queryContent, useAsyncData, definePageMeta, useHead } from '#imports'
+import { useRoute, computed, queryContent, useAsyncData, definePageMeta, useHead, useSeoMeta } from '#imports'
 import type { QueryBuilderParams } from '@nuxt/content'
 
 import PostList from '~/components/post/PostList.vue'
@@ -42,6 +42,10 @@ const headTitle = computed(() => {
 
 useHead({
   title: headTitle.value,
+})
+
+useSeoMeta({
+  description: `${headTitle.value}です。`,
 })
 
 const query = computed<QueryBuilderParams>(() => {


### PR DESCRIPTION
## やりたいこと
 - ブログをメッセージアプリに貼ったところ、ogp の改修が間に合っていなかったので、修正

## やってこと
 - ホーム / 音楽 / お酒 / 記事 / カテゴライズされた記事、それぞれにタイトルと説明文を設定する