### PR TITLE
記事の front matter に categories がないときにパースエラーにならないように

### DIFF
--- a/utils/config/nitro/getContentRoutes.ts
+++ b/utils/config/nitro/getContentRoutes.ts
@@ -8,7 +8,7 @@ import { per, categoryUrlParamsMap } from '../../../constant/post'
 const getFrontMatter = (markdownPath: string): { categories: string[], draft: boolean } => {
   const { data: frontmatter } = parseFrontMatter(readFileSync(markdownPath, 'utf8'))
   const { categories, draft } = frontmatter
-  return { categories, draft }
+  return { categories: categories || [], draft }
 }
 
 export const getContentRoutes = (): string[] => {


### PR DESCRIPTION
## やりたいこと
 - 記事の frontmatter にカテゴリがないと、記事のカテゴライズのときに処理が落ちてしまう。なので、仮に設定されていなく、パース処理でカテゴリが見つからないとき空配列を返すようにして、エラーが起こらないように。