### PR TITLE
カテゴライズされた記事一覧のレイアウトの高さを修正

### DIFF
--- a/src/pages/posts/categories/[category]/[page].vue
+++ b/src/pages/posts/categories/[category]/[page].vue
@@ -84,7 +84,7 @@ const allPagesNum = computed(() => {
 </script>
 
 <template>
-  <div class="p-2 max-w-6xl mx-auto h-screen">
+  <div class="p-2 max-w-6xl mx-auto min-h-screen">
     <div class="py-2">
       <PostList :query="query" />
     </div>


### PR DESCRIPTION
## やりたいこと
 - レイアウト全体の高さが min-height: 100vh ではなく、背景色が画面外で適用されていなかったのを修正