### PR TITLE
各記事のページの記事数を 12 にする

### DIFF
--- a/constant/post.ts
+++ b/constant/post.ts
@@ -1,4 +1,4 @@
-export const per = 5
+export const per = 12
 
 export const categoryUrlParamsMap: Record<string, string> = {
   'GitHub Actions': 'githubactions',


### PR DESCRIPTION
## やりたいこと
 - ページネーションの動作確認のため、各記事のページの記事数を少なくしていたので、本来の数に修正する 